### PR TITLE
Namespace wasm and parser types

### DIFF
--- a/src/sexpr-wasm.c
+++ b/src/sexpr-wasm.c
@@ -165,11 +165,11 @@ int main(int argc, char** argv) {
   }
   fclose(f);
 
-  Source source;
+  WasmSource source;
   source.start = data;
   source.end = data + fsize;
 
-  Tokenizer tokenizer;
+  WasmTokenizer tokenizer;
   tokenizer.source = source;
   tokenizer.loc.pos = source.start;
   tokenizer.loc.line = 1;

--- a/src/wasm-gen.h
+++ b/src/wasm-gen.h
@@ -1,8 +1,8 @@
 #ifndef WASM_GEN_H
 #define WASM_GEN_H
 
-struct Tokenizer;
+struct WasmTokenizer;
 
-void gen_file(struct Tokenizer* tokenizer);
+void gen_file(struct WasmTokenizer* tokenizer);
 
 #endif /* WASM_GEN_H */

--- a/src/wasm-parse.h
+++ b/src/wasm-parse.h
@@ -1,92 +1,75 @@
 #ifndef WASM_PARSE_H
 #define WASM_PARSE_H
 
-typedef enum TokenType {
-  TOKEN_TYPE_EOF,
-  TOKEN_TYPE_OPEN_PAREN,
-  TOKEN_TYPE_CLOSE_PAREN,
-  TOKEN_TYPE_ATOM,
-  TOKEN_TYPE_STRING,
-} TokenType;
+#include "wasm.h"
 
-typedef struct SourceLocation {
-  const char* pos;
-  int line;
-  int col;
-} SourceLocation;
-
-typedef struct SourceRange {
-  SourceLocation start;
-  SourceLocation end;
-} SourceRange;
-
-typedef struct Token {
-  TokenType type;
-  SourceRange range;
-} Token;
-
-typedef struct Source {
+typedef struct WasmSource {
   const char* start;
   const char* end;
-} Source;
+} WasmSource;
 
-typedef struct Tokenizer {
-  Source source;
-  SourceLocation loc;
-} Tokenizer;
+typedef struct WasmTokenizer {
+  WasmSource source;
+  WasmSourceLocation loc;
+} WasmTokenizer;
 
-struct Module;
-struct Function;
-enum Opcode;
 
-typedef uintptr_t Cookie;
+typedef uintptr_t WasmParserCookie;
 
-typedef struct Parser {
+typedef struct WasmParser {
   void* user_data;
-  void (*before_module)(struct Module* m, void* user_data);
-  void (*after_module)(struct Module* m, void* user_data);
-  void (*before_function)(struct Module* m,
-                          struct Function* f,
+  void (*before_module)(struct WasmModule* m, void* user_data);
+  void (*after_module)(struct WasmModule* m, void* user_data);
+  void (*before_function)(struct WasmModule* m,
+                          struct WasmFunction* f,
                           void* user_data);
-  void (*after_function)(struct Module* m,
-                         struct Function* f,
+  void (*after_function)(struct WasmModule* m,
+                         struct WasmFunction* f,
                          int num_exprs,
                          void* user_data);
-  void (*before_export)(struct Module* m, void* user_data);
-  void (*after_export)(struct Module* m, int function_index, void* user_data);
+  void (*before_export)(struct WasmModule* m, void* user_data);
+  void (*after_export)(struct WasmModule* m,
+                       int function_index,
+                       void* user_data);
 
-  void (*before_binary)(enum Opcode opcode, void* user_data);
-  Cookie (*before_block)(void* user_data);
-  void (*after_block)(int num_exprs, Cookie cookie, void* user_data);
+  void (*before_binary)(enum WasmOpcode opcode, void* user_data);
+  WasmParserCookie (*before_block)(void* user_data);
+  void (*after_block)(int num_exprs, WasmParserCookie cookie, void* user_data);
   void (*after_break)(int depth, void* user_data);
   void (*before_call)(int function_index, void* user_data);
-  void (*before_compare)(enum Opcode opcode, void* user_data);
-  void (*before_const)(enum Opcode opcode, void* user_data);
-  void (*before_convert)(enum Opcode opcode, void* user_data);
-  Cookie (*before_label)(void* user_data);
-  void (*after_label)(int num_exprs, Cookie cookie, void* user_data);
+  void (*before_compare)(enum WasmOpcode opcode, void* user_data);
+  void (*before_const)(enum WasmOpcode opcode, void* user_data);
+  void (*before_convert)(enum WasmOpcode opcode, void* user_data);
+  WasmParserCookie (*before_label)(void* user_data);
+  void (*after_label)(int num_exprs, WasmParserCookie cookie, void* user_data);
   void (*after_get_local)(int remapped_index, void* user_data);
-  Cookie (*before_loop)(void* user_data);
-  void (*after_loop)(int num_exprs, Cookie cookie, void* user_data);
-  Cookie (*before_if)(void* user_data);
-  void (*after_if)(int with_else, Cookie cookie, void* user_data);
-  void (*before_load)(enum Opcode opcode, uint8_t access, void* user_data);
+  WasmParserCookie (*before_loop)(void* user_data);
+  void (*after_loop)(int num_exprs, WasmParserCookie cookie, void* user_data);
+  WasmParserCookie (*before_if)(void* user_data);
+  void (*after_if)(int with_else, WasmParserCookie cookie, void* user_data);
+  void (*before_load)(enum WasmOpcode opcode, uint8_t access, void* user_data);
   void (*after_load_global)(int index, void* user_data);
   void (*after_nop)(void* user_data);
   void (*before_return)(void* user_data);
   void (*before_set_local)(int index, void* user_data);
-  void (*before_store)(enum Opcode opcode, uint8_t access, void* user_data);
+  void (*before_store)(enum WasmOpcode opcode, uint8_t access, void* user_data);
   void (*before_store_global)(int index, void* user_data);
-  void (*before_unary)(enum Opcode opcode, void* user_data);
+  void (*before_unary)(enum WasmOpcode opcode, void* user_data);
 
   void (*u32_literal)(uint32_t value, void* user_data);
   void (*u64_literal)(uint64_t value, void* user_data);
   void (*f32_literal)(float value, void* user_data);
   void (*f64_literal)(double value, void* user_data);
-} Parser;
+} WasmParser;
 
-size_t copy_string_contents(Token t, char* dest, size_t size);
-void parse_module(Parser* parser, Tokenizer* tokenizer);
-void parse_file(Parser* parser, Tokenizer* tokenizer);
+#ifdef __cplusplus
+extern "C" {
+#endif
+size_t wasm_copy_string_contents(WasmToken t, char* dest, size_t size);
+void wasm_parse_module(WasmParser* parser, WasmTokenizer* tokenizer);
+void wasm_parse_file(WasmParser* parser, WasmTokenizer* tokenizer);
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* WASM_PARSE_H */

--- a/src/wasm-parse.h
+++ b/src/wasm-parse.h
@@ -62,14 +62,8 @@ typedef struct WasmParser {
   void (*f64_literal)(double value, void* user_data);
 } WasmParser;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-size_t wasm_copy_string_contents(WasmToken t, char* dest, size_t size);
-void wasm_parse_module(WasmParser* parser, WasmTokenizer* tokenizer);
-void wasm_parse_file(WasmParser* parser, WasmTokenizer* tokenizer);
-#ifdef __cplusplus
-}
-#endif
+
+EXTERN_C size_t wasm_copy_string_contents(WasmToken t, char* dest, size_t size);
+EXTERN_C void wasm_parse_file(WasmParser* parser, WasmTokenizer* tokenizer);
 
 #endif /* WASM_PARSE_H */

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -4,6 +4,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+#define EXTERN_C extern "C"
+#else
+#define EXTERN_C
+#endif
+
 /* These values match the v8-native-prototype's type's values */
 typedef enum WasmType {
   TYPE_VOID,
@@ -255,8 +261,8 @@ typedef struct WasmToken {
     size_t size;                                        \
     size_t capacity;                                    \
   } type##Vector;                                       \
-  void wasm_destroy_##name##_vector(type##Vector* vec); \
-  type* wasm_append_##name(type##Vector* vec);
+  EXTERN_C void wasm_destroy_##name##_vector(type##Vector* vec); \
+  EXTERN_C type* wasm_append_##name(type##Vector* vec);
 
 DECLARE_VECTOR(type, WasmType)
 


### PR DESCRIPTION
Prepend the prefixes "Wasm" to types and "wasm_" to functions
which are exported from the parser. This helps avoid name clashes.

Also use C linkage for the functions
